### PR TITLE
Updates schedule of classes link

### DIFF
--- a/server/templates/section.html
+++ b/server/templates/section.html
@@ -121,7 +121,7 @@
     <% var courseParts = splitCourseId(term[0].get('course_id')); %>
     <% var questId = termIdToQuestId(termId); %>
 
-    <a href="http://classes.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=<%- questId %>&subject=<%- courseParts[0] %>&cournum=<%- courseParts[1] %>"
+    <a href="https://classes.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=<%- questId %>&subject=<%- courseParts[0] %>&cournum=<%- courseParts[1] %>"
         target="_blank">
       classes.uwaterloo.ca</a>.
    </small>

--- a/server/templates/section.html
+++ b/server/templates/section.html
@@ -121,9 +121,9 @@
     <% var courseParts = splitCourseId(term[0].get('course_id')); %>
     <% var questId = termIdToQuestId(termId); %>
 
-    <a href="http://www.adm.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=<%- questId %>&subject=<%- courseParts[0] %>&cournum=<%- courseParts[1] %>"
+    <a href="http://classes.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=<%- questId %>&subject=<%- courseParts[0] %>&cournum=<%- courseParts[1] %>"
         target="_blank">
-      www.adm.uwaterloo.ca</a>.
+      classes.uwaterloo.ca</a>.
    </small>
 <% }); %>
 {% endcall %}


### PR DESCRIPTION
Looks like they shut down http://www.adm.uwaterloo.ca/ this morning.

This PR updates the link to the schedule of classes to the new subdomain http://classes.uwaterloo.ca/